### PR TITLE
ADD: JFrog repo in pyproject

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,10 +36,13 @@ test-coverage-fail:
 	@pytest --cov=g3 --cov-report=term-missing --cov-report=html --cov-fail-under=80
 
 # Deployment
+clean:
+	@rm -rf ./dist
+
 build:
 	@poetry build
 
 publish:
-	@poetry publish -r jfrog -u=$ARTIFACTORY_USERNAME -p=$ARTIFACTORY_API_KEY
+	@poetry publish --repository jfrog --username $(ARTIFACTORY_USERNAME) --password $(ARTIFACTORY_API_KEY)
 
-deploy: build publish
+deploy: clean build publish

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,15 @@ description = "An AI-powered CLI tool to help you write better commit messages a
 authors = ["Ioannis Karachristos <ioannis@workable.com>", "Kostis Kyrkos <konstantinos.kyrkos@workable.com>"]
 readme = "README.md"
 
+[[tool.poetry.source]]
+name = "PyPI"
+priority = "primary"
+
+[[tool.poetry.source]]
+name = "jfrog"
+url = "https://workable.jfrog.io/workable/api/pypi/pypi-virtual"
+priority = "supplemental"
+
 [tool.poetry.scripts]
 g3 = "g3.main:app"
 


### PR DESCRIPTION
## 📝 Description

Adds jfrog repo to pyproject.yaml.

## 📸 Overview

#### Before

You had to add `jfrog` to poetry's local config before executing the `deploy` target as follows:
```
$ poetry config repositories.jfrog https://workable.jfrog.io/workable/api/pypi/pypi-virtual
```

#### After

Simply execute the `deploy` target without any prerequisite:

````
$ make deploy

Building g3 (0.1.0)
  - Building sdist
  - Built g3-0.1.0.tar.gz
  - Building wheel
  - Built g3-0.1.0-py3-none-any.whl

Publishing g3 (0.1.0) to jfrog
 - Uploading g3-0.1.0-py3-none-any.whl 100%
 - Uploading g3-0.1.0.tar.gz 100%
```

## ℹ️ Issue

Contributes on https://github.com/Workable/g3/issues/12
