### PR TITLE
Disable pretty exceptions in Typer

### DIFF
--- a/g3/main.py
+++ b/g3/main.py
@@ -11,7 +11,7 @@ from g3.domain.message_tone import MessageTone
 from g3.generate.commit.messages.creator import Creator as CommitMessageCreator
 from g3.generate.pr.messages.creator import Creator as PRMessageCreator
 
-app = typer.Typer()
+app = typer.Typer(pretty_exceptions_enable=False)
 
 
 @app.callback()


### PR DESCRIPTION
- The pretty exceptions feature in Typer was disabled.
- This change was made to enhance error handling in the application.

## 📝 Description

Please include a summary of the proposal, relevant motivation and context.

## 📸 Overview

#### Before

_{Please add a screenshot here}_

#### After

_{Please add a screenshot here}_

## ℹ️ Issue

Closes issue \#1
