### PR TITLE
Add exit signal handler to main.py

### DIFF
--- a/g3/main.py
+++ b/g3/main.py
@@ -1,3 +1,4 @@
+import signal
 from typing import Annotated
 
 import typer
@@ -10,6 +11,14 @@ from g3.config import config
 from g3.domain.message_tone import MessageTone
 from g3.generate.commit.messages.creator import Creator as CommitMessageCreator
 from g3.generate.pr.messages.creator import Creator as PRMessageCreator
+
+
+def signal_handler(sig, frame):
+    print("Ctrl+C pressed. Exiting...")
+    exit(0)
+
+
+signal.signal(signal.SIGINT, signal_handler)
 
 app = typer.Typer()
 


### PR DESCRIPTION
- Added a function `signal_handler` to handle SIGINT signal (Ctrl+C) in `main.py`
- This function will print a message and exit the program when Ctrl+C is pressed
- This change allows graceful termination of the program when the user interrupts it

## 📝 Description

Please include a summary of the proposal, relevant motivation and context.

## 📸 Overview

#### Before

_{Please add a screenshot here}_

#### After

_{Please add a screenshot here}_

## ℹ️ Issue

Closes issue \#1
