### PR TITLE
Make temperature field optional in OpenAIConfig due to type handling bug

### DIFF
--- a/g3/config/handler.py
+++ b/g3/config/handler.py
@@ -117,6 +117,3 @@ class Defaults:
 
     def set_defaults(self, value, default=None):
         return value if value else default
-
-
-# print(Defaults(ConfigHandler()).__dict__)

--- a/g3/config/handler.py
+++ b/g3/config/handler.py
@@ -116,4 +116,4 @@ class Defaults:
         self.pr_description_max_words = self.set_defaults(file_config.pr_description_max_words, 500)
 
     def set_defaults(self, value, default=None):
-        return value if value else default
+        return value if value is not None else default

--- a/g3/config/handler.py
+++ b/g3/config/handler.py
@@ -2,6 +2,8 @@ import configparser
 from pathlib import Path
 from typing import Any, Optional
 
+from g3.domain.message_tone import MessageTone
+
 CONFIG_DIR = ".g3"
 CONFIG_FILE = "config"
 
@@ -97,3 +99,24 @@ class ConfigHandler:
     def save_config(self):
         with open(self.config_file, "w") as f:
             self.config.write(f)
+
+
+class Defaults:
+    def __init__(self, file_config: ConfigHandler):
+        self.github_token = self.set_defaults(file_config.github_token)
+        self.openai_key = self.set_defaults(file_config.openai_key)
+        self.api_base = self.set_defaults(file_config.api_base)
+        self.deployment_id = self.set_defaults(file_config.deployment_id)
+        self.api_type = self.set_defaults(file_config.api_type, "open_ai")
+        self.model = self.set_defaults(file_config.model, "gpt-4-0613")
+        self.temperature = self.set_defaults(file_config.temperature, 0.0)
+        self.api_version = self.set_defaults(file_config.api_version, "latest")
+        self.tone = self.set_defaults(file_config.tone, MessageTone.FRIENDLY.value)
+        self.commit_description_max_words = self.set_defaults(file_config.commit_description_max_words, 50)
+        self.pr_description_max_words = self.set_defaults(file_config.pr_description_max_words, 500)
+
+    def set_defaults(self, value, default=None):
+        return value if value else default
+
+
+# print(Defaults(ConfigHandler()).__dict__)

--- a/g3/config/openai.py
+++ b/g3/config/openai.py
@@ -12,7 +12,7 @@ class OpenAIConfig(BaseSettings):
     api_base: Optional[str] = None
     deployment_id: Optional[str] = None
     model: str = "gpt-4-0613"
-    temperature: float = 0
+    temperature: Optional[float] = 0
 
     class Config:
         extra = Extra.ignore

--- a/g3/main.py
+++ b/g3/main.py
@@ -8,6 +8,7 @@ from rich.panel import Panel
 from rich.text import Text
 
 from g3.config import config
+from g3.config.handler import Defaults
 from g3.domain.message_tone import MessageTone
 from g3.generate.commit.messages.creator import Creator as CommitMessageCreator
 from g3.generate.pr.messages.creator import Creator as PRMessageCreator
@@ -51,27 +52,37 @@ def configure() -> None:
             padding=1,
         )
     )
-
+    defaults = Defaults(config)
     questions = [
-        inquirer.Text("github_token", message="Your GitHub token"),
-        inquirer.Text("openai_key", message="Your OpenAI key"),
-        inquirer.List("openai_api_type", message="OpenAI API type", choices=["open_ai", "azure"], default="open_ai"),
+        inquirer.Text("github_token", message="Your GitHub token", default=defaults.github_token),
+        inquirer.Text("openai_key", message="Your OpenAI key", default=defaults.openai_key),
+        inquirer.List(
+            "openai_api_type", message="OpenAI API type", choices=["open_ai", "azure"], default=defaults.api_type
+        ),
         inquirer.Text(
-            "openai_api_base", message="OpenAI API base", ignore=lambda answers: answers["openai_api_type"] == "open_ai"
+            "openai_api_base",
+            message="OpenAI API base",
+            ignore=lambda answers: answers["openai_api_type"] == "open_ai",
+            default=defaults.api_base,
         ),
         inquirer.Text(
             "openai_deployment_id",
             message="OpenAI deployment ID",
             ignore=lambda answers: answers["openai_api_type"] == "open_ai",
+            default=defaults.deployment_id,
         ),
-        inquirer.Text("openai_model", message="OpenAI model", default="gpt-4-0613"),
-        inquirer.Text("openai_temperature", message="OpenAI temperature", default="0.0"),
-        inquirer.Text("openai_api_version", message="OpenAI API version", default="latest"),
-        inquirer.List(
-            "tone", message="Default tone", choices=[t.value for t in MessageTone], default=MessageTone.FRIENDLY.value
+        inquirer.Text("openai_model", message="OpenAI model", default=defaults.model),
+        inquirer.Text("openai_temperature", message="OpenAI temperature", default=defaults.temperature),
+        inquirer.Text("openai_api_version", message="OpenAI API version", default=defaults.api_version),
+        inquirer.List("tone", message="Default tone", choices=[t.value for t in MessageTone], default=defaults.tone),
+        inquirer.Text(
+            "commit_description_max_words",
+            message="Commit description max words",
+            default=defaults.commit_description_max_words,
         ),
-        inquirer.Text("commit_description_max_words", message="Commit description max words", default="50"),
-        inquirer.Text("pr_description_max_words", message="PR description max words", default="500"),
+        inquirer.Text(
+            "pr_description_max_words", message="PR description max words", default=defaults.pr_description_max_words
+        ),
     ]
     answers = inquirer.prompt(questions)
 


### PR DESCRIPTION
- Changed the type of the temperature field in the OpenAIConfig class from float to Optional[float].
- This change was made to handle cases where the temperature field is not provided in the configuration file.

## 📝 Description

Please include a summary of the proposal, relevant motivation and context.

## 📸 Overview

#### Before

_{Please add a screenshot here}_

#### After

_{Please add a screenshot here}_

## ℹ️ Issue

Closes issue \#1
