### PR TITLE
Add Push Functionality and fixed PR prompt skip JIRA if missing

### DIFF
--- a/g3/generate/pr/messages/creator.py
+++ b/g3/generate/pr/messages/creator.py
@@ -4,7 +4,9 @@ from g3.domain.message_tone import MessageTone
 from g3.generate.client import OpenAIChat
 from g3.generate.pr.prompts.creator import Creator as PromptCreator
 from g3.generate.preview.cli import Presenter
+from g3.git import client as git
 from g3.git.client import get_commit_messages
+from g3.git.gitinfo import GitInfo
 from g3.github.client import Client as GHClient
 from g3.github.github_info import GithubInfo
 
@@ -14,6 +16,7 @@ class Creator:
         self.prompt_creator = PromptCreator()
         self.openai = OpenAIChat()
         self.gh = GHClient()
+        self.git_info = GitInfo()
 
     def create(self, tone: MessageTone, jira=None, include=None, edit: Optional[int] = None) -> None:
         if edit:
@@ -33,6 +36,7 @@ class Creator:
 
             title = reviewed_message.split("\n")[1]
             description = reviewed_message.split(title)[1]
+            git.push("origin", self.git_info.branch, force=True)
             self.gh.update_pull_request(pr.number, title, description)
             print(f"Successfully updated PR: {pr.html_url}")
         else:
@@ -47,5 +51,6 @@ class Creator:
 
             title = reviewed_message.split("\n")[1]
             description = reviewed_message.split(title)[1]
+            git.push("origin", self.git_info.branch)
             pr = self.gh.create_pull_request(title, description)
             print(f"Opened PR: {pr.html_url}")

--- a/g3/generate/pr/prompts/creator.py
+++ b/g3/generate/pr/prompts/creator.py
@@ -2,9 +2,7 @@ from typing import Optional
 
 from g3.domain.message_tone import MessageTone
 from g3.generate.pr.prompts.template import pr_template
-from g3.git.client import get_commit_messages
 from g3.git.gitinfo import GitInfo
-from g3.github.github_info import GithubInfo
 from g3.main import config
 
 
@@ -23,8 +21,7 @@ class Creator:
     @property
     def user_messages(self) -> list:
         content = f"""Please provide a pull request description for the provided commit messages.
- Commits: ```{self.commit_messages}```.
- The commit messages are form a git branch named {self.git_info.branch}.
+ Commits: ```{self.commit_messages}```. The commit messages are form a git branch named {self.git_info.branch}.
  The commit messages are from a git repository named {self.git_info.repo}."""
 
         return [
@@ -47,20 +44,15 @@ class Creator:
  Leave an new empty line always after the title. The pull reuqest's description should be under
  {config.pr_description_max_words} words in total and it should be helpful to the reader in order to
  understand the changes made. The reader of the pull request description needs to understand the changes
- in order to approve the pull request or ask for the needed changes. If the commit messages have referenced
- jira tickets, then include them in the pull request description too, but not in the title. Also, if the user
- provides any additional jira tickets, then include them in the pull request description too.
- Put the jira tickets in bullet points using the template provided.
- Use the following tone when creating the pull request
- message: {tone}.
- {pr_template}"""
+ in order to approve the pull request or ask for the needed changes. If Jira tickets are provided then include them in
+ the pull request description. Use the following tone when creating the pull request message: {tone}."""
         if include:
-            content += f" Include in your response the following: ```{include}```."
+            content += f" Include in your response the following: {include}"
         if jira:
             content += f" Incorporate the following Jira ticket: ```{jira}```."
         content += (
-            "Your response should be in Github markdown syntax format and you should split each "
-            "sentence to a new line."
+            f" Your response should be in Github markdown syntax format and comply on the following template:"
+            f"```{pr_template}```."
         )
 
         return [{"role": "system", "content": content.replace("\n", "")}]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "g3"
-version = "0.4.0"
+version = "0.4.1"
 description = "An AI-powered CLI tool to help you write better commit messages and PRs."
 authors = [
     "Panos Antonakos <antonakos@workable.com>",


### PR DESCRIPTION


## Description
This pull request introduces the push functionality to the PR message creator and updates the version in `pyproject.toml`. It also includes a fix for the PR prompt to skip JIRA ticket if missing.

## Changes
- Added GitInfo to the Creator class in `g3/generate/pr/messages/creator.py`
- Implemented push functionality to update and create pull requests
- Fixed PR prompt to skip JIRA ticket if missing
- Updated the version number in `pyproject.toml` from 0.4.0 to 0.4.1

## Jira tickets
- PROD-1

cc @ikarachristos
