### PR TITLE
ADD: FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+custom: ["https://www.paypal.me/workableteamg"]


### PR DESCRIPTION
## 📝 Description

Adds GH sponsor button to the repo. Used Paypal for now, instead of a [GH sponsors](https://github.com/sponsors) cause that would require we make a request via GH's Workable organization. No need for that for now since we will probably develop the project during working hours.

## ℹ️ Issue

Closes #105
