### PR TITLE
Remove JFROG references and minor update to `yml` string quoting

### DIFF
--- a/.github/workflows/publish_to_jfrog_and_pypi.yml
+++ b/.github/workflows/publish_to_jfrog_and_pypi.yml
@@ -1,4 +1,4 @@
-name: Push project build to JFrog Artifactory and PyPI
+name: Push project build to PyPI
 
 on:
   release:
@@ -7,15 +7,15 @@ on:
   workflow_dispatch:
     inputs:
       branch_to_build:
-        description: 'Specify the branch you want to build'
+        description: "Specify the branch you want to build"
         required: false
         default: $GITHUB_REF
       version_to_build:
-        description: 'Specify the version you want to build: use SEMVER format only'
+        description: "Specify the version you want to build: use SEMVER format only"
         required: false
         default: "0.0.0.dev"
       build_description:
-        description: 'Provide a description for the build'
+        description: "Provide a description for the build"
         required: true
         default: "Custom build"
 
@@ -24,8 +24,6 @@ jobs:
     runs-on: ubuntu-latest
     environment: Deploy
     env:
-      ARTIFACTORY_USERNAME: ${{ vars.JFROG_USER }}
-      ARTIFACTORY_API_KEY: ${{ secrets.JFROG_API_KEY}}
       POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_API_KEY }}
 
     steps:
@@ -66,7 +64,7 @@ jobs:
         if: always()
         uses: slackapi/slack-github-action@v1.24.0
         with:
-          channel-id: 'C05PLVB1Y04'
+          channel-id: "C05PLVB1Y04"
           payload-file-path: ".github/workflows/payloads/release_payload.json"
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_WORKABLE_APP_OAUTH_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - 'main'
+      - "main"
 
 jobs:
   build:
@@ -73,7 +73,7 @@ jobs:
         if: ( always() && github.event_name == 'pull_request' && !(github.event.action == 'closed' && github.event.pull_request.merged == true) )
         uses: slackapi/slack-github-action@v1.24.0
         with:
-          channel-id: 'C05P40DCGAK'
+          channel-id: "C05P40DCGAK"
           payload-file-path: ".github/workflows/payloads/pr_payload.json"
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_WORKABLE_APP_OAUTH_TOKEN }}
@@ -83,7 +83,7 @@ jobs:
         id: slack
         uses: slackapi/slack-github-action@v1.24.0
         with:
-          channel-id: 'C05P40DCGAK'
+          channel-id: "C05P40DCGAK"
           payload-file-path: ".github/workflows/payloads/push_payload.json"
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_WORKABLE_APP_OAUTH_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -42,12 +42,9 @@ clean:
 build:
 	@poetry build
 
-publish-to-jfrog:
-	@poetry publish --repository jfrog --username $(ARTIFACTORY_USERNAME) --password $(ARTIFACTORY_API_KEY)
-
 publish-to-pypi:
 	@poetry publish
 
-publish: publish-to-jfrog publish-to-pypi
+publish: publish-to-pypi
 
 deploy: clean build publish


### PR DESCRIPTION
## 📝 Description

JFROG was used as an intermediate storage solution until the project could be published to PyPI. Now that the project is hosted in PyPI, JFROG is no longer required, and removing it will remove a small maintenance overhead.
- Remove JFrog related items from Makefile

A small change was introduced to make the `yml` files more consistent, by using double quotes in `String` types.
- Adjust Slack notifications (change quoting)

## ℹ️ Issue

Closes #130